### PR TITLE
Stripped out hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # French Press
 ---
 
-An opinionated ReactJs + Webpack generator for CoffeeScript with hot reloader.
+An opinionated ReactJs + Webpack generator for CoffeeScript.
 
 <img src="https://pixabay.com/static/uploads/photo/2013/07/13/11/56/coffee-159007_960_720.png" alt="A french press" align="right"/>
 ---

--- a/templates/webpack-config/base.config.js
+++ b/templates/webpack-config/base.config.js
@@ -5,7 +5,6 @@ module.exports = {
 
   entry: [
     'webpack-dev-server/client?http://0.0.0.0:8080',
-    'webpack/hot/only-dev-server',
     './app/index.coffee'
   ],
 

--- a/templates/webpack-config/webpack.config.js
+++ b/templates/webpack-config/webpack.config.js
@@ -2,5 +2,4 @@ var webpack = require('webpack');
 var base = require('./base.config.js');
 base.devServer = {port: 8080}
 base.devtool = 'eval'
-base.plugins.push(new webpack.HotModuleReplacementPlugin())
 module.exports = base


### PR DESCRIPTION
# What it does:
- Removes hot reload from webpack config but leaves the actual setup code in place for a future patch
# Why it does it:
- The hot reloader was causing strange render issues with React for some reason. See #8 
